### PR TITLE
CI: run Clippy on main crate with all features enabled - OOPS apologies for missing this in PR 2285 - PERSONAL CI TESTING

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,12 +463,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      # We want to be free of any warnings, so deny them.
+      # We want to be free of any warnings (with all features enabled), so deny them.
       # - Allow `clippy::disallowed_types` as a workaround since `disallowed_types` configured in `.clippy.toml`
       #   is only intended for the main `rustls` crate.
       - run: ./admin/clippy -- --deny warnings --allow clippy::disallowed_types
-      # - Keep the main crate free of all warnings.
-      - run: cargo clippy -p rustls -- --deny warnings
+      # - Keep the main crate free of all warnings (with all features enabled).
+      - run: cargo clippy -p rustls --all-features -- --deny warnings
 
   clippy-nightly:
     name: Clippy (Nightly)
@@ -491,8 +491,8 @@ jobs:
       # - Ignore `clippy::disallowed_types` as a workaround since `disallowed_types` configured in `.clippy.toml`
       #   is only intended for main `rustls` crate.
       - run: ./admin/clippy -- --allow clippy::disallowed_types
-      # Check the main crate for any Clippy nightly warnings, but do not deny them.
-      - run: cargo clippy -p rustls
+      # Check the main crate for any Clippy nightly warnings (with all features enabled), but do not deny them.
+      - run: cargo clippy -p rustls --all-features
 
   check-external-types:
     name: Validate external types appearing in public API


### PR DESCRIPTION
Apologies I missed this in rustls/rustls#2285 - need to run Clippy to catch `alloc::sync::Arc` aka `std::sync::Arc` on main `rustls` crate with all features enabled.

I am raising this on my own development fork for personal CI testing before proposing upstream.