### PR TITLE
fix spacing comment in Cargo workspace default-members - PERSONAL WIP SAVE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 default-members = [
-  # ---
+  # ---
   "examples",
   "rustls",
 ]


### PR DESCRIPTION
I accidentally put a non-breaking space into a comment in recent PR: https://github.com/rustls/rustls/pull/2307

This is a proposal to simply use a normal ASCII space instead.

Hexdump shows me `c2 a0` for the non-breaking space character that I am replacing in this proposal - see also: https://stackoverflow.com/questions/2774471/what-is-c2-a0-in-mime-encoded-quoted-printable-text/2774507#2774507