### PR TITLE
fix & update comment for default-members in Cargo workspace - DRAFT FOR PERSONAL CI TESTING

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 default-members = [
-  # ---
+  # build & test these by default:
   "examples",
   "rustls",
 ]


### PR DESCRIPTION
I would like to use a nicer comment in default-members for Cargo workspace in top-level `Cargo.toml` & get rid of the Unicode non-breaking space character that I accidentally put into recent PR: https://github.com/rustls/rustls/pull/2307

This goes one step beyond simply replacing the non-breaking space character as I proposed in PERSONAL DRAFT PR: #11

See also statement from PERSONAL DRAFT PR #11:

> Hexdump shows me `c2 a0` for the non-breaking space character that I am replacing in this proposal - see also: https://stackoverflow.com/questions/2774471/what-is-c2-a0-in-mime-encoded-quoted-printable-text/2774507#2774507